### PR TITLE
Allow empty cost spec

### DIFF
--- a/beancount_parser/grammar/beancount.lark
+++ b/beancount_parser/grammar/beancount.lark
@@ -80,7 +80,7 @@ simple_directive: option
 // Posting
 total_cost: "{{" amount "}}"
 both_cost: "{" number_expr  "#" amount "}"
-cost_spec: "{" cost_item ["," cost_item]* "}"
+cost_spec: "{" (cost_item ("," cost_item)*)? "}"
 cost_item: amount | DATE | ESCAPED_STRING | ASTERISK
 ?cost: total_cost | both_cost | cost_spec
 

--- a/tests/grammar/directives/test_posting.py
+++ b/tests/grammar/directives/test_posting.py
@@ -36,6 +36,7 @@ def posting_parser(make_parser: typing.Callable) -> Lark:
         'Assets:Bank -10.0 TWD { "my-label", 2021-06-07, 100.56 USD }',
         'Assets:Bank -10.0 TWD { "my-label", 2021-06-07, 100.56 USD, * }',
         "Assets:Bank -10.0 TWD { * }",
+        "Assets:Bank -10.0 TWD {}",
         "! Assets:Bank -10.0 TWD",
         "* Assets:Bank -10.0 TWD",
     ],


### PR DESCRIPTION
Empty cost can be used when there's no ambiguity between lots (e.g., when selling all holdings) or to fall back to the account's booking method.

An example can be found in the [Beancount Language Syntax](https://beancount.github.io/docs/beancount_language_syntax.html#reducing-positions).

Fixes #16.